### PR TITLE
feat: enable toggline public DNS zone

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -1,20 +1,23 @@
 resource "aws_route53_zone" "internal" {
-  name = var.internal_root_domain
-
+  name          = var.internal_root_domain
   force_destroy = true
+
   vpc {
     vpc_id = module.vpc.vpc_id
   }
 }
 
 resource "aws_route53_zone" "public" {
-  name = var.public_root_domain
+  count = local.enable_public_route53_zone ? 1 : 0
 
+  name          = var.public_root_domain
   force_destroy = true
 }
 
 resource "aws_route53_record" "caa" {
-  zone_id = aws_route53_zone.public.zone_id
+  count = local.enable_public_route53_zone ? 1 : 0
+
+  zone_id = aws_route53_zone.public[0].zone_id
   name    = var.public_root_domain
   type    = "CAA"
   ttl     = 300

--- a/outputs.tf
+++ b/outputs.tf
@@ -60,9 +60,9 @@ output "ecr" {
 
 output "public_domain" {
   value = {
-    nameservers = aws_route53_zone.public.name_servers
-    name        = aws_route53_zone.public.name
-    zone_id     = aws_route53_zone.public.id
+    nameservers = aws_route53_zone.public[0].name_servers
+    name        = aws_route53_zone.public[0].name
+    zone_id     = aws_route53_zone.public[0].id
   }
   description = "A map of public Route53 zone attributes: nameservers, name, zone_id."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -6,6 +6,7 @@ locals {
     var.tags,
     { nuon_id = var.nuon_id },
   )
+  enable_public_route53_zone = tobool(var.enable_public_route53_zone)
 }
 
 variable "prefix_override" {
@@ -45,4 +46,10 @@ variable "public_root_domain" {
 variable "runner_install_role" {
   type        = string
   description = "The role that is used to install the runner, and should be granted access."
+}
+
+variable "enable_public_route53_zone" {
+  type        = string
+  default     = "true"
+  description = "Provision a public Route53 zone."
 }


### PR DESCRIPTION
Can't provision public DNS in AWS gov cloud. Allow toggline this component off to support this use-case.