### PR TITLE
fix: remove outputs from missing modules

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,10 +1,8 @@
 output "runner" {
   value = {
-    runner_iam_role_arn  = module.runner_iam_role.iam_role_arn
-    odr_iam_role_arn     = module.odr_iam_role.iam_role_arn
     install_iam_role_arn = module.runner_install_iam_role.iam_role_arn
   }
-  description = "A map of runner attributes: runner_iam_role_arn, odr_iam_role_arn, install_iam_role_arn"
+  description = "A map of runner attributes: install_iam_role_arn"
 }
 
 output "ecs_cluster" {


### PR DESCRIPTION
These modules were recently removed, but it looks like we forgot to remove the outputs.